### PR TITLE
add route.exactly to match criteria

### DIFF
--- a/modules/matchRoutesToLocation.js
+++ b/modules/matchRoutesToLocation.js
@@ -8,7 +8,7 @@ const mergePatterns = (a, b) => {
 
 const matchRoutesToLocation = (routes, location, matchedRoutes=[], params={}, parentPattern='') => {
   routes.forEach((route) => {
-    const nestedPattern = mergePatterns(parentPattern, route.pattern)
+    const nestedPattern = mergePatterns(parentPattern, route.pattern, route.exactly)
     const match = matchPattern(nestedPattern, location)
 
     if (match) {


### PR DESCRIPTION
for a situation like this 

```js
{
    pattern: '/',
    name: 'home',
    component: Home,
    exactly: true,
    initActions: [testAsyncAction]
  },
  {
    pattern: '/login',
    name: 'login',
    component: Login,
    exactly: true,
  },

```

for the `/login` route it matches both the home and login route